### PR TITLE
Add gitignore for Jetbrain IDE

### DIFF
--- a/Backend/.gitignore
+++ b/Backend/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 .env
+.idea/
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
For those who are using Jetbrain IDE, the .idea directory must be ignored