### PR TITLE
Add schedule updating procedure to UpdateTutor repo

### DIFF
--- a/Backend/internal/schemas/schema.schedule.go
+++ b/Backend/internal/schemas/schema.schedule.go
@@ -1,12 +1,17 @@
 package schemas
 
-//type TimeSlot struct {
-//	Day  int `json:"day,omitempty"`
-//	Hour int `json:"hour,omitempty"`
-//}
-
-// a tuple specifying the occupied hour on a day of the week
-type Schedule struct {
+type TimeSlot struct {
 	Day  int `json:"day,omitempty"`
 	Hour int `json:"hour,omitempty"`
+}
+
+// a tuple specifying the occupied hour on a day of the week
+type Schedule []TimeSlot
+
+func (s *Schedule) AvailableTimeArrays() *[7][24]bool {
+	aT := [7][24]bool{}
+	for _, tS := range *s {
+		aT[tS.Day][tS.Hour] = true
+	}
+	return &aT
 }

--- a/Backend/internal/schemas/schema.tutor.go
+++ b/Backend/internal/schemas/schema.tutor.go
@@ -20,6 +20,7 @@ type SchemaTutor struct {
 	Description       string    `json:"description"`
 	OmiseBankToken    string    `json:"omise_bank_token"`
 	CitizenId         string    `json:"citizen_id"`
+	Schedule          Schedule  `json:"schedule"`
 }
 
 type SchemaGetTutor struct {
@@ -49,12 +50,12 @@ type SchemaUpdateTutor struct {
 	Phone     string `json:"phone"`
 	Address   string `json:"address"`
 	//ProfilePictureURL string    `json:"profile_picture_URL"`
-	Birthdate      time.Time  `json:"birthdate"`
-	Gender         string     `json:"gender"`
-	Description    string     `json:"description"`
-	OmiseBankToken string     `json:"omise_bank_token"`
-	Email          string     `json:"email"`
-	Schedules      []Schedule `json:"schedules"`
+	Birthdate      time.Time `json:"birthdate"`
+	Gender         string    `json:"gender"`
+	Description    string    `json:"description"`
+	OmiseBankToken string    `json:"omise_bank_token"`
+	Email          string    `json:"email"`
+	Schedules      Schedule  `json:"schedules"`
 }
 
 type SchemaDeleteTutor struct {

--- a/Backend/internal/services/service.tutor.go
+++ b/Backend/internal/services/service.tutor.go
@@ -118,6 +118,7 @@ func (s *serviceTutor) UpdateTutor(tutorUpdate *schemas.SchemaUpdateTutor) (*sch
 		Description:    *tutor.Description,
 		OmiseBankToken: *tutor.OmiseBankToken,
 		CitizenId:      tutor.CitizenID,
+		Schedule:       tutorUpdate.Schedules,
 	}, nil
 }
 


### PR DESCRIPTION
edit tutor profile route is implemented under api/v1 PUT(/tutor)
Details:
   - edit tutor and edit tutor's schedule is currently a monolith. Therefore, the update request should also include the schedules. This will be refactored within the next PR.
*Warn* Frontend shouldn't use the edit tutor route in this commit as a reference yet.